### PR TITLE
Fix QSizePolicy usage

### DIFF
--- a/gui/search_window.py
+++ b/gui/search_window.py
@@ -61,9 +61,11 @@ class SearchWindow(QDialog):
             label.setPixmap(pix)
             label.setScaledContents(True)
             label.setFixedSize(100, 100)
-            label.setSizePolicy(
-                QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed
-            )
+            try:
+                fixed = QSizePolicy.Policy.Fixed
+            except AttributeError:
+                fixed = QSizePolicy.Fixed
+            label.setSizePolicy(fixed, fixed)
             label.setToolTip(f"{rec.title}\n{rec.description}")
             self.grid.addWidget(label, i // 4, i % 4)
 


### PR DESCRIPTION
## Summary
- support both `QSizePolicy.Policy.Fixed` and `QSizePolicy.Fixed`
- keep widgets imported from `PySide6.QtWidgets`

## Testing
- `python -m py_compile gui/search_window.py`

------
https://chatgpt.com/codex/tasks/task_e_6855dfdc70688325b4f9c29a60c6b253